### PR TITLE
fixed puppet4 (puppetserver) error

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,14 +24,14 @@
 class postfix::params{
   # Set OS family specific variables here, and test for supported OS families.
   case $::osfamily{
-    Debian: {
+    /Debian/: {
       $sendmail_ensure  = 'purged'
       $package          = 'postfix'
       $service          = 'postfix'
       $config_file      = '/etc/postfix/main.cf'
       $daemon_directory = '/usr/lib/postfix'
     }
-    RedHat: {
+    /RedHat/: {
       $sendmail_ensure  = 'absent'
       $package          = 'postfix'
       $service          = 'postfix'


### PR DESCRIPTION
switch case is not correct for new puppetserver:

> Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Error while evaluating a Function Call, The postfix module does not support the Debian family of operating systems. at /etc/puppetlabs/code/environments/development/modules/postfix/manifests/params.pp:42:7
