### PR TITLE
Added inet_protocols parameter.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,12 @@
 #
 # Parameters:
 #
+# [*header_checks*]
+#   If not undef, sets the header_checks field in main.cfg to
+#    regexp:/etc/postfix/header_checks
+#   It populates the header_checks file with the contents of this string.
+#   Default: undef
+#
 # Actions:
 #
 # Requires:
@@ -36,7 +42,8 @@ class postfix (
   $daemon_directory        = $::postfix::params::daemon_directory,
   $inet_interfaces         = $::postfix::params::inet_interfaces,
   $inet_protocols          = $::postfix::params::inet_protocols,
-  $enable_daemon_directory = $::postfix::params::enable_daemon_directory
+  $enable_daemon_directory = $::postfix::params::enable_daemon_directory,
+  $header_checks           = undef,
 ) inherits postfix::params {
 
   if $remove_sendmail {
@@ -59,6 +66,14 @@ class postfix (
     before => [
       File['postfix_config']
     ],
+  }
+
+  if $header_checks {
+    file{$postfix::params::header_checks_file:
+      ensure  => file,
+      content => $header_checks,
+      before  => File['postfix_config'],
+    }
   }
 
   file{'postfix_config':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,7 @@ class postfix (
   $relayhost_port   = undef,
   $daemon_directory = $::postfix::params::daemon_directory,
   $inet_interfaces  = $::postfix::params::inet_interfaces,
+  $inet_protocols   = $::postfix::params::inet_protocols,
 ) inherits postfix::params {
 
   if $remove_sendmail {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,14 +28,15 @@
 
 # [Remember: No empty lines between comments and class definition]
 class postfix (
-  $remove_sendmail  = undef,
-  $myorigin         = undef,
-  $mydestination    = undef,
-  $relayhost        = undef,
-  $relayhost_port   = undef,
-  $daemon_directory = $::postfix::params::daemon_directory,
-  $inet_interfaces  = $::postfix::params::inet_interfaces,
-  $inet_protocols   = $::postfix::params::inet_protocols,
+  $remove_sendmail         = undef,
+  $myorigin                = undef,
+  $mydestination           = undef,
+  $relayhost               = undef,
+  $relayhost_port          = undef,
+  $daemon_directory        = $::postfix::params::daemon_directory,
+  $inet_interfaces         = $::postfix::params::inet_interfaces,
+  $inet_protocols          = $::postfix::params::inet_protocols,
+  $enable_daemon_directory = $::postfix::params::enable_daemon_directory
 ) inherits postfix::params {
 
   if $remove_sendmail {
@@ -75,5 +76,4 @@ class postfix (
       File['postfix_config']
     ]
   }
-
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,7 +42,12 @@ class postfix::params{
       fail("The postfix module does not support the ${::osfamily} family of operating systems.")
     }
   }
-  
+  if $::lsbdistcodename == 'xenial' {
+    $enable_daemon_directory = false
+  }else{
+    $enable_daemon_directory = true
+  }
+
   # Set OS independent varibles here
   $sendmail_package   = 'sendmail'
   $sendmailcf_package = 'sendmail-cf'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,6 +42,9 @@ class postfix::params{
       fail("The postfix module does not support the ${::osfamily} family of operating systems.")
     }
   }
+
+  $header_checks_file = '/etc/postfix/header_checks'
+
   if $::lsbdistcodename == 'xenial' {
     $enable_daemon_directory = false
   }else{

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -48,4 +48,5 @@ class postfix::params{
   $sendmailcf_package = 'sendmail-cf'
   $sendmail_service   = 'sendmail'
   $inet_interfaces    = 'localhost'
+  $inet_protocols     = 'all'
 }

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -41,7 +41,9 @@ command_directory = /usr/sbin
 # daemon programs (i.e. programs listed in the master.cf file). This
 # directory must be owned by root.
 #
+<% if @daemon_directory %>
 daemon_directory = <%= @daemon_directory %>
+<% end %>
 
 # The data_directory parameter specifies the location of Postfix-writable
 # data files (caches, random numbers). This directory must be owned

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -121,7 +121,7 @@ myorigin = <%= @myorigin %>
 inet_interfaces = <%= @inet_interfaces %>
 
 # Enable IPv4, and IPv6 if supported
-inet_protocols = all
+inet_protocols = <%= @inet_protocols %>
 
 # The proxy_interfaces parameter specifies the network interface
 # addresses that this mail system receives mail on by way of a

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -561,6 +561,10 @@ alias_database = hash:/etc/aliases
 # For details, see "man header_checks".
 #
 #header_checks = regexp:/etc/postfix/header_checks
+<% if @header_checks -%>
+header_checks = regexp:/etc/postfix/header_checks
+local_header_rewrite_clients = static:all
+<% end -%>
 
 # FAST ETRN SERVICE
 #

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -41,7 +41,7 @@ command_directory = /usr/sbin
 # daemon programs (i.e. programs listed in the master.cf file). This
 # directory must be owned by root.
 #
-<% if @daemon_directory %>
+<% if @enable_daemon_directory == true %>
 daemon_directory = <%= @daemon_directory %>
 <% end %>
 


### PR DESCRIPTION
The inet_protocols parameter is necessary to fix a bug with postfix when
ip6 has been disabled on a server.  The following blog describes the
necesary changes.

http://truemetal.org/universe/blog/2013/03/disable-ipv6-on-linux-centos